### PR TITLE
Support of paths.public param

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,11 +13,11 @@ copyfilemon.prototype.onCompile = function(data, path, callback) {
     var dir = key;
     var files = params.plugins.copyfilemon[key];
     if(typeof files === 'string'){
-      filemon.copyFolderRecursiveAsync(files, 'public/'+dir);
+      filemon.copyFolderRecursiveAsync(files, params.paths.public + '/'+dir);
     }else{
       var i =0, l = files.length;
       for(i;i<l;i++)
-        filemon.copyFolderRecursiveAsync(files[i], 'public/'+dir);
+        filemon.copyFolderRecursiveAsync(files[i], params.paths.public + '/'+dir);
     }
 
   });


### PR DESCRIPTION
Currently it always copy files into public dir while this param can override this path
